### PR TITLE
feat: 添加一键快速总结当前页面功能

### DIFF
--- a/background.js
+++ b/background.js
@@ -60,6 +60,8 @@ chrome.commands.onCommand.addListener(async (command) => {
     await handleTabCommand('TOGGLE_SIDEBAR_toggle_sidebar');
   } else if (command === 'clear_chat') {
     await handleTabCommand('CLEAR_CHAT');
+  } else if (command === 'quick_summary') {
+    await handleTabCommand('QUICK_SUMMARY');
   }
 });
 

--- a/content.js
+++ b/content.js
@@ -427,6 +427,28 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
       return true;
     }
 
+    // 快速总结功能的公共函数
+    async function handleQuickSummary() {
+        try {
+            // 如果侧边栏没有打开，先打开它
+            if (sidebar && !sidebar.isVisible) {
+                sidebar.toggle();
+            }
+
+            const iframe = sidebar?.sidebar?.querySelector('.cerebr-sidebar__iframe');
+            if (iframe) {
+                iframe.contentWindow.postMessage({ type: 'QUICK_SUMMARY_COMMAND' }, '*');
+                return { success: true };
+            } else {
+                console.error('找不到侧边栏iframe');
+                return { success: false, error: 'Iframe not found' };
+            }
+        } catch (error) {
+            console.error('处理快速总结命令失败:', error);
+            return { success: false, error: error.message };
+        }
+    }
+
     // 处理侧边栏切换命令
     if (message.type === 'TOGGLE_SIDEBAR_onClicked' || message.type === 'TOGGLE_SIDEBAR_toggle_sidebar') {
         try {
@@ -464,24 +486,9 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
     // 处理快速总结命令
     if (message.type === 'QUICK_SUMMARY') {
-        try {
-            // 如果侧边栏没有打开，先打开它
-            if (sidebar && !sidebar.isVisible) {
-                sidebar.toggle();
-            }
-
-            const iframe = sidebar?.sidebar?.querySelector('.cerebr-sidebar__iframe');
-            if (iframe) {
-                iframe.contentWindow.postMessage({ type: 'QUICK_SUMMARY_COMMAND' }, '*');
-                sendResponse({ success: true });
-            } else {
-                console.error('找不到侧边栏iframe');
-                sendResponse({ success: false, error: 'Iframe not found' });
-            }
-        } catch (error) {
-            console.error('处理快速总结命令失败:', error);
-            sendResponse({ success: false, error: error.message });
-        }
+        handleQuickSummary().then(result => {
+            sendResponse(result);
+        });
         return true;
     }
 

--- a/content.js
+++ b/content.js
@@ -462,6 +462,29 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         return true;
     }
 
+    // 处理快速总结命令
+    if (message.type === 'QUICK_SUMMARY') {
+        try {
+            // 如果侧边栏没有打开，先打开它
+            if (sidebar && !sidebar.isVisible) {
+                sidebar.toggle();
+            }
+
+            const iframe = sidebar?.sidebar?.querySelector('.cerebr-sidebar__iframe');
+            if (iframe) {
+                iframe.contentWindow.postMessage({ type: 'QUICK_SUMMARY_COMMAND' }, '*');
+                sendResponse({ success: true });
+            } else {
+                console.error('找不到侧边栏iframe');
+                sendResponse({ success: false, error: 'Iframe not found' });
+            }
+        } catch (error) {
+            console.error('处理快速总结命令失败:', error);
+            sendResponse({ success: false, error: error.message });
+        }
+        return true;
+    }
+
     // 处理获取页面内容请求
     if (message.type === 'GET_PAGE_CONTENT_INTERNAL') {
         console.log('收到获取页面内容请求');

--- a/manifest.json
+++ b/manifest.json
@@ -38,6 +38,13 @@
         "mac": "MacCtrl+X"
       },
       "description": "清空聊天记录"
+    },
+    "quick_summary": {
+      "suggested_key": {
+        "default": "Alt+S",
+        "mac": "MacCtrl+S"
+      },
+      "description": "快速总结当前页面"
     }
   },
   "background": {

--- a/sidebar.html
+++ b/sidebar.html
@@ -52,6 +52,12 @@
                     <path d="M5 4V12H11V4" stroke="currentColor" stroke-width="1.5"/>
                 </svg>
             </div>
+            <div class="menu-item" id="quick-summary">
+                <span>快速总结</span>
+                <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+                    <path d="M2 4h12M2 8h8M2 12h4" stroke="currentColor" stroke-width="1.5"/>
+                </svg>
+            </div>
             <div class="menu-item" id="api-settings-toggle">
                 <span>API 设置</span>
                 <svg width="16" height="16" viewBox="0 0 16 16" fill="none">

--- a/sidebar.js
+++ b/sidebar.js
@@ -573,6 +573,26 @@ document.addEventListener('DOMContentLoaded', async () => {
                     }, event.data.timeout);
                 }
             }
+        } else if (event.data.type === 'QUICK_SUMMARY_COMMAND') {
+            // 处理快速总结命令
+            (async () => {
+                // 清空聊天记录
+                chatContainer.innerHTML = '';
+                chatHistory = [];
+                saveChatHistory();
+
+                // 获取页面内容
+                const content = await getPageContent();
+                if (!content) {
+                    appendMessage('获取页面内容失败', 'ai', true);
+                    return;
+                }
+
+                // 构建总结请求
+                messageInput.textContent = `请总结这个页面的主要内容，用简洁的语言描述。`;
+                // 直接发送消息
+                sendMessage();
+            })();
         }
     });
 

--- a/sidebar.js
+++ b/sidebar.js
@@ -1053,7 +1053,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         chatHistory = [];
 
         // 构建总结请求
-        messageInput.textContent = `请总结这个页面的主要内容，用简洁的语言描述。`;
+        messageInput.textContent = `请总结这个页面的主要内容。`;
         // 直接发送消息
         sendMessage();
     }

--- a/sidebar.js
+++ b/sidebar.js
@@ -574,25 +574,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                 }
             }
         } else if (event.data.type === 'QUICK_SUMMARY_COMMAND') {
-            // 处理快速总结命令
-            (async () => {
-                // 清空聊天记录
-                chatContainer.innerHTML = '';
-                chatHistory = [];
-                saveChatHistory();
-
-                // 获取页面内容
-                const content = await getPageContent();
-                if (!content) {
-                    appendMessage('获取页面内容失败', 'ai', true);
-                    return;
-                }
-
-                // 构建总结请求
-                messageInput.textContent = `请总结这个页面的主要内容，用简洁的语言描述。`;
-                // 直接发送消息
-                sendMessage();
-            })();
+            performQuickSummary();
         }
     });
 
@@ -1035,9 +1017,8 @@ document.addEventListener('DOMContentLoaded', async () => {
         selection.addRange(range);
     });
 
-    // 快速总结功能
-    const quickSummary = document.getElementById('quick-summary');
-    quickSummary.addEventListener('click', async () => {
+    // 快速总结的公共函数
+    async function performQuickSummary() {
         // 清空聊天记录
         chatContainer.innerHTML = '';
         chatHistory = [];
@@ -1056,7 +1037,11 @@ document.addEventListener('DOMContentLoaded', async () => {
         messageInput.textContent = `请总结这个页面的主要内容，用简洁的语言描述。`;
         // 直接发送消息
         sendMessage();
-    });
+    }
+
+    // 快速总结功能
+    const quickSummary = document.getElementById('quick-summary');
+    quickSummary.addEventListener('click', () => performQuickSummary());
 
     // 添加点击事件监听
     chatContainer.addEventListener('click', () => {

--- a/sidebar.js
+++ b/sidebar.js
@@ -1026,12 +1026,31 @@ document.addEventListener('DOMContentLoaded', async () => {
         // 关闭设置菜单
         settingsMenu.classList.remove('visible');
 
+        // 显示加载状态
+        appendMessage('正在准备页面内容...', 'ai', true);
+
+        // 如果网页问答没有开启，先开启它
+        if (!webpageSwitch.checked) {
+            webpageSwitch.checked = true;
+            const domain = await getCurrentDomain();
+            if (domain) {
+                await saveWebpageSwitch(domain, true);
+            }
+        }
+
         // 获取页面内容
         const content = await getPageContent();
         if (!content) {
             appendMessage('获取页面内容失败', 'ai', true);
             return;
         }
+
+        // 更新 pageContent
+        pageContent = content;
+
+        // 移除加载状态消息
+        chatContainer.innerHTML = '';
+        chatHistory = [];
 
         // 构建总结请求
         messageInput.textContent = `请总结这个页面的主要内容，用简洁的语言描述。`;

--- a/sidebar.js
+++ b/sidebar.js
@@ -1015,6 +1015,29 @@ document.addEventListener('DOMContentLoaded', async () => {
         selection.addRange(range);
     });
 
+    // 快速总结功能
+    const quickSummary = document.getElementById('quick-summary');
+    quickSummary.addEventListener('click', async () => {
+        // 清空聊天记录
+        chatContainer.innerHTML = '';
+        chatHistory = [];
+        saveChatHistory();
+        // 关闭设置菜单
+        settingsMenu.classList.remove('visible');
+
+        // 获取页面内容
+        const content = await getPageContent();
+        if (!content) {
+            appendMessage('获取页面内容失败', 'ai', true);
+            return;
+        }
+
+        // 构建总结请求
+        messageInput.textContent = `请总结这个页面的主要内容，用简洁的语言描述。`;
+        // 直接发送消息
+        sendMessage();
+    });
+
     // 添加点击事件监听
     chatContainer.addEventListener('click', () => {
         // 击聊天区域时让输入框失去焦点


### PR DESCRIPTION
### 功能描述
添加了一键总结当前网页内容的功能，支持快捷键和UI按钮两种触发方式。

### 主要更改
1. **基础功能实现**
   - 在侧边栏添加"快速总结"按钮
   - 实现网页内容的快速总结功能
   - 自动处理网页问答开关状态

2. **快捷键支持**
   - 添加快速总结快捷键（Windows: Alt+S, Mac: MacCtrl+S）
   - 在manifest.json中配置快捷键
   - 实现快捷键命令处理逻辑

3. **用户体验优化**
   - 添加内容加载状态提示
   - 使用快速总结时自动开启网页问答功能

### 涉及文件
- `sidebar.html`: 添加快速总结按钮
- `sidebar.js`: 实现快速总结核心功能
- `content.js`: 添加消息处理逻辑
- `background.js`: 添加快捷键支持
- `manifest.json`: 配置快捷键

### 使用方法
1. 点击侧边栏中的"快速总结"按钮
2. 或使用快捷键（Windows: Alt+S, Mac: MacCtrl+S）
3. 系统会自动分析当前页面内容并生成总结

### 注意事项
- 使用快速总结功能时会自动开启网页问答功能
- 总结过程中会清空当前的聊天记录
- 需要等待页面内容加载完成 