### PR TITLE
尝试修复win10下第三方输入中文问题

### DIFF
--- a/src/components/message-input.js
+++ b/src/components/message-input.js
@@ -62,6 +62,11 @@ export function initMessageInput(config) {
             config: uiConfig.textarea
         });
 
+        // 如果正在使用输入法，则不处理 placeholder
+        if (isComposing) {
+            return;
+        }
+
         // 处理 placeholder 的显示
         if (this.textContent.trim() === '' && !this.querySelector('.image-tag')) {
             // 如果内容空且没有图片标签，清空内容以显示 placeholder


### PR DESCRIPTION
问题描述: #30 
问题分析: 问题在于 input 事件监听器在输入法组合（composition）期间错误地清空了输入框。
解决方案: 通过在监听器中增加对 isComposing 状态的检查.

